### PR TITLE
Fix diagram url on "Token Minting and Supply" page

### DIFF
--- a/docs/token-minting-and-supply.mdx
+++ b/docs/token-minting-and-supply.mdx
@@ -59,7 +59,7 @@ Also, the governance mechanism that approves the minting of tokens could be comp
 
 For the market, however, what really matters is the supply of tokens going into and out of the market. To simplify things we can say that:
 - Tokens are _only_ minted from off-chain activity.
-- Once toknes are minted there is some demand to use them in the World of Ethereum (WoE).
+- Once tokens are minted there is some demand to use them in the World of Ethereum (WoE).
 - When tokens are burned users either get cash out of the curve or in-game features/points.
 - In-game points can only be used in-game and cannot be redeemed directly for on-chain tokens.
 - When in-game points are used to unlock features, boost, or whatever else there is a delay between that conversion event and Cred being realized.

--- a/docs/token-minting-and-supply.mdx
+++ b/docs/token-minting-and-supply.mdx
@@ -48,7 +48,7 @@ Talk about how the supply schedule is super important as well as various governa
   ]
 }>
     <TabItem value="diagram">
-        <img alt="AraCred Token Market" src={useBaseUrl('img/aracred-token-market.svg')} />
+        <img alt="AraCred Token Market" src={useBaseUrl('img/aracred-token-market-overview.svg')} />
         <a href="https://www.lucidchart.com/invitations/accept/53bb9538-8ec1-472a-a955-8ff0b09b06b6">Click here to explore and/or fork the diagram</a>
     </TabItem>
 </Tabs>


### PR DESCRIPTION
Found this broken URL while reading through the docs; seems this was renamed at some point and not updated.